### PR TITLE
Work with characters above U+FFFF

### DIFF
--- a/chardialog.cpp
+++ b/chardialog.cpp
@@ -3,24 +3,25 @@
 
 class CharsTable;
 
-CharDialog::CharDialog(QChar ch, const QString & fontFamily,
+CharDialog::CharDialog(uint ch, const QString & fontFamily,
                        const CategoryString & categories,
                        QWidget *parent)
     : QDialog(parent)
 {
     this->ch = ch;
+    QString text = CharsTable::textChar(ch);
     setupUi(this);
-    setWindowTitle(tr("Character %1").arg(ch));
-    character->setText(ch);
+    setWindowTitle(tr("Character %1").arg(text));
+    character->setText(text);
 
     QFont fn = QFont(character->font());
     fn.setFamily(fontFamily);
     character->setFont(fn);
 
-    unicode->setText(CharsTable::unicodeChar(ch.unicode()));
+    unicode->setText(CharsTable::unicodeChar(ch));
     utf8->setText(CharsTable::utf8Char(ch));
-    xmlDecimal->setText(CharsTable::xmlDecimal(ch.unicode()));
-    category->setText(categories[ch.category()]);
+    xmlDecimal->setText(CharsTable::xmlDecimal(ch));
+    category->setText(categories[QChar::category(ch)]);
 }
 
 CharDialog::~CharDialog()

--- a/chardialog.h
+++ b/chardialog.h
@@ -10,10 +10,10 @@ typedef QMap<QChar::Category, QString> CategoryString;
 
 class CharDialog : public QDialog, Ui::CharDialog
 {
-    QChar ch;
+    uint ch;
 
 public:
-    CharDialog(QChar ch = QChar(), const QString & fontFamily = QString(),
+    CharDialog(uint ch, const QString & fontFamily = QString(),
                const CategoryString & categories = CategoryString(),
                QWidget *parent = 0);
     ~CharDialog();

--- a/charstable.cpp
+++ b/charstable.cpp
@@ -198,7 +198,7 @@ void CharsTable::paintEvent(QPaintEvent *event)
     for (uint row = beginRow; row <= endRow; ++row) {
         for (uint column = beginColumn; column <= endColumn; ++column) {
             uint currentKey = row * COLUMNS + column;
-			QString text(CharsTable::textChar(currentKey));
+            QString text(CharsTable::textChar(currentKey));
             painter.setClipRect(column*squareSize, row*squareSize,
                                 squareSize, squareSize);
 

--- a/charstable.cpp
+++ b/charstable.cpp
@@ -78,14 +78,14 @@ void CharsTable::setSubset(QFontDatabase::WritingSystem subset)
     this->subset = subset;
 }
 
-void CharsTable::goToChar(const QChar & character)
+void CharsTable::goToChar(uint character)
 {
     QWidget *viewport = qobject_cast<QWidget *>(parent()->parent());
     QScrollArea *scrollArea = qobject_cast<QScrollArea *>(viewport->parent());
     QScrollBar *bar = scrollArea->verticalScrollBar();
 
-    bar->setValue(character.unicode() / COLUMNS * squareSize);
-    key = character.unicode();
+    bar->setValue(character / COLUMNS * squareSize);
+    key = character;
     update();
 }
 
@@ -97,9 +97,9 @@ QString CharsTable::unicodeChar(uint key)
     return "U+" + code;
 }
 
-QString CharsTable::utf8Char(QChar ch)
+QString CharsTable::utf8Char(uint ch)
 {
-    QByteArray bytes = QString(ch).toUtf8();
+    QByteArray bytes = CharsTable::textChar(ch).toUtf8();
     QString utf8Text;
     for (int i = 0; i < bytes.size(); ++i) {
         if (i > 0)
@@ -109,6 +109,16 @@ QString CharsTable::utf8Char(QChar ch)
     return utf8Text;
 }
 
+QString CharsTable::textChar(uint codepoint)
+{
+    if (QChar::requiresSurrogates(codepoint)) {
+        QChar array[]{QChar::highSurrogate(codepoint), QChar::lowSurrogate(codepoint)};
+        return QString(array, 2);
+    } else {
+        return QString(QChar(codepoint));
+    }
+}
+
 inline QString CharsTable::xmlDecimal(uint key, bool escape)
 {
     return QString(escape ? "&amp;#%1;" : "&#%1;").arg(key);
@@ -116,8 +126,9 @@ inline QString CharsTable::xmlDecimal(uint key, bool escape)
 
 void CharsTable::goToChar(const QString & character)
 {
-    if (!character.isEmpty())
-        goToChar(character[0]);
+    QVector<uint> codepoints = character.toUcs4();
+    if (!codepoints.isEmpty())
+        goToChar(codepoints[0]);
 }
 
 void CharsTable::mouseMoveEvent(QMouseEvent *event)
@@ -125,27 +136,27 @@ void CharsTable::mouseMoveEvent(QMouseEvent *event)
     QPoint widgetPosition = mapFromGlobal(event->globalPos());
     uint key = (widgetPosition.y() / squareSize) * COLUMNS +
                widgetPosition.x() / squareSize;
-    QChar ch(key);
+    QString ch(CharsTable::textChar(key));
     QString text = QString::fromLatin1("<p>Character: <span style=\"\
 font-size: 24pt; font-family: %1\">%2</span></p>"
 "Unicode: %3<br/>"
 "UTF-8: %4<br/>"
 "XML decimal: %5")
         .arg(font.family(), ch,
-             unicodeChar(key), utf8Char(ch), xmlDecimal(key, true));
+             unicodeChar(key), utf8Char(key), xmlDecimal(key, true));
     QToolTip::showText(event->globalPos(), text, this);
 }
 
 void CharsTable::mousePressEvent(QMouseEvent *event)
 {
     key = (event->y() / squareSize) * COLUMNS + event->x() / squareSize;
-    QChar qKey = currentChar();
+    uint qKey = currentKey();
 
     if (event->button() == Qt::LeftButton) {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
-        if (qKey.category() != QChar::Other_NotAssigned)
+        if (QChar::category(qKey) != QChar::Other_NotAssigned)
 #else
-        if (qKey.category() != QChar::NoCategory)
+        if (QChar::category(qKey) != QChar::NoCategory)
 #endif
             emit characterSelected(qKey);
         update();
@@ -184,9 +195,10 @@ void CharsTable::paintEvent(QPaintEvent *event)
     if (!systemColors)
         painter.setPen(QPen(Qt::black));
 
-    for (int row = beginRow; row <= endRow; ++row) {
-        for (int column = beginColumn; column <= endColumn; ++column) {
-            int currentKey = row * COLUMNS + column;
+    for (uint row = beginRow; row <= endRow; ++row) {
+        for (uint column = beginColumn; column <= endColumn; ++column) {
+            uint currentKey = row * COLUMNS + column;
+			QString text(CharsTable::textChar(currentKey));
             painter.setClipRect(column*squareSize, row*squareSize,
                                 squareSize, squareSize);
 
@@ -196,9 +208,9 @@ void CharsTable::paintEvent(QPaintEvent *event)
                                  QPalette().highlight());
 
             painter.drawText(column*squareSize + (squareSize / 2) -
-                             fontMetrics.width(QChar(currentKey))/2,
+                             fontMetrics.boundingRect(text).width()/2,
                              row*squareSize + 4 + fontMetrics.ascent(),
-                             QString(QChar(currentKey)));
+                             text);
         }
     }
 

--- a/charstable.h
+++ b/charstable.h
@@ -22,7 +22,8 @@ class CharsTable : public QWidget
 
     QFont font;
     QFontDatabase::WritingSystem subset;
-    int squareSize, key;
+    int squareSize;
+    uint key;
     bool systemColors;
     CategoryString categories;
 
@@ -37,9 +38,10 @@ public:
     CharsTable(QWidget *parent = 0);
     ~CharsTable();
     QSize sizeHint() const;
+    static QString textChar(uint codepoint);
 
 signals:
-    void characterSelected(const QChar & character);
+    void characterSelected(uint character);
 
 public slots:
     void setFontStyle(const QFont & font);
@@ -48,11 +50,11 @@ public slots:
     void setFontSize(const QString & size) { setFontSize(size.toDouble()); }
     void setSubset(QFontDatabase::WritingSystem subset);
     static QString unicodeChar(uint key);
-    static QString utf8Char(QChar ch);
+    static QString utf8Char(uint ch);
     inline static QString xmlDecimal(uint key, bool escape = false);
-    int currentKey() { return key; }
-    QChar currentChar() { return QChar(key); }
-    void goToChar(const QChar & character);
+    uint currentKey() { return key; }
+    QString currentChar() { return CharsTable::textChar(key); }
+    void goToChar(uint character);
     void goToChar(const QString & character);
     void useSystemColors(bool enable) { systemColors = enable; update(); }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -135,7 +135,7 @@ void MainWindow::loadSettings(bool reload)
 
     QVariant key = s.value("key");
     if (key.isValid())
-        charsTable->goToChar(QChar(key.toInt()));
+        charsTable->goToChar(key.toInt());
 
     QVariant recentList0 = s.value("recentList");
     if (recentList0.isValid()) {
@@ -309,7 +309,7 @@ void MainWindow::on_actionCopy_triggered()
     case 1:
         //text->
     case 2:
-        copy(QString(charsTable->currentChar()));
+        copy(charsTable->currentChar());
     case 3:
         break;
     default:
@@ -350,9 +350,16 @@ void MainWindow::on_copy_clicked()
     copy(copyBuffer->text());
 }
 
-void MainWindow::on_charsTable_characterSelected(const QChar & character)
+void MainWindow::on_charsTable_characterSelected(uint character)
 {
-    copyBuffer->setText(copyBuffer->text() + character);
+	QString text;
+    if (QChar::requiresSurrogates(character)) {
+        QChar array[]{QChar::highSurrogate(character), QChar::lowSurrogate(character)};
+        text = QString(array, 2);
+    } else {
+        text = QChar(character);
+    }
+    copyBuffer->setText(copyBuffer->text() + text);
 }
 
 void MainWindow::on_codeSearch_editingFinished()
@@ -360,7 +367,7 @@ void MainWindow::on_codeSearch_editingFinished()
     const QString & text = codeSearch->text();
     if (unicodeRegExp.indexIn(text) != -1) {
         uint code = unicodeRegExp.cap(1).toInt(0, 16);
-        charsTable->goToChar(QChar(code));
+        charsTable->goToChar(code);
         return;
     }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -352,7 +352,7 @@ void MainWindow::on_copy_clicked()
 
 void MainWindow::on_charsTable_characterSelected(uint character)
 {
-	QString text;
+    QString text;
     if (QChar::requiresSurrogates(character)) {
         QChar array[]{QChar::highSurrogate(character), QChar::lowSurrogate(character)};
         text = QString(array, 2);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -54,7 +54,7 @@ public slots:
     void on_actionExit_triggered();
     void copy(const QString & text);
     void on_copy_clicked();
-    void on_charsTable_characterSelected(const QChar & character);
+    void on_charsTable_characterSelected(uint character);
     void on_codeSearch_editingFinished();
     void recentAction_triggered();
     void updateFontList(bool force = false);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -278,7 +278,7 @@
              </size>
             </property>
             <property name="maxLength">
-             <number>1</number>
+             <number>2</number>
             </property>
            </widget>
           </item>
@@ -752,7 +752,7 @@
    <header>charstable.h</header>
    <container>1</container>
    <slots>
-    <slot>goToChar(QChar)</slot>
+    <slot>goToChar(uint)</slot>
     <slot>goToChar(QString)</slot>
    </slots>
   </customwidget>


### PR DESCRIPTION
Hi!
Here is patch for working with characters with high unicode codepoints. QChar is able to store only subset of characters, so changed to uint, as in newer Qt functions.