### PR TITLE
Qt6 compatibility via replacing deprecated interfaces

### DIFF
--- a/charstable.h
+++ b/charstable.h
@@ -46,8 +46,7 @@ signals:
 public slots:
     void setFontStyle(const QFont & font);
     void setFontFamily(const QString & family) { font.setFamily(family); }
-    void setFontSize(qreal size) { font.setPointSizeF(size); refresh(); }
-    void setFontSize(const QString & size) { setFontSize(size.toDouble()); }
+    void setFontSize(const QString & size) { font.setPointSizeF(size.toDouble()); refresh(); }
     void setSubset(QFontDatabase::WritingSystem subset);
     static QString unicodeChar(uint key);
     static QString utf8Char(uint ch);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -5,13 +5,13 @@
 #include <QFileDialog>
 #include <QFile>
 #include <QMimeData>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include <QUrl>
 
 class SettingsDialog;
 
-QRegExp MainWindow::unicodeRegExp = QRegExp("^u\\+([0-9a-f]{4,})", Qt::CaseInsensitive);
-//QRegExp MainWindow::utf8RegExp = QRegExp("(0x[0-9a-f]*( |))*", Qt::CaseInsensitive);
+QRegularExpression MainWindow::unicodeRegExp = QRegularExpression("^u\\+([0-9a-f]{4,})", QRegularExpression::CaseInsensitiveOption);
+//QRegularExpression MainWindow::utf8RegExp = QRegularExpression("(0x[0-9a-f]*( |))*", QRegularExpression::CaseInsensitiveOption);
 
 MainWindow::MainWindow(const QStringList & args, QWidget *parent)
     : QMainWindow(parent)
@@ -74,12 +74,12 @@ void MainWindow::processArgs(const QStringList & args)
 
 void MainWindow::setValidators()
 {
-    codeSearch->setValidator(new QRegExpValidator(
-        //QRegExp("(^u\\+[0-9a-f]{4,}|(0x[0-9a-f]*( |))*|[0-9]*)",
-        QRegExp("(^u\\+[0-9a-f]{4,})",
-                Qt::CaseInsensitive), this));
+    codeSearch->setValidator(new QRegularExpressionValidator(
+        //QRegularExpression("(^u\\+[0-9a-f]{4,}|(0x[0-9a-f]*( |))*|[0-9]*)",
+        QRegularExpression("(^u\\+[0-9a-f]{4,})",
+                QRegularExpression::CaseInsensitiveOption), this));
 
-    fontSize->setValidator(new QRegExpValidator(QRegExp("^([0-9]{1,})"), this));
+    fontSize->setValidator(new QRegularExpressionValidator(QRegularExpression("^([0-9]{1,})"), this));
 }
 
 void MainWindow::loadSettings(bool reload)
@@ -367,8 +367,9 @@ void MainWindow::on_charsTable_characterSelected(uint character)
 void MainWindow::on_codeSearch_editingFinished()
 {
     const QString & text = codeSearch->text();
-    if (unicodeRegExp.indexIn(text) != -1) {
-        uint code = unicodeRegExp.cap(1).toInt(0, 16);
+    QRegularExpressionMatch m = unicodeRegExp.match(text);
+    if (m.hasMatch()) {
+        uint code = m.captured(1).toInt(0, 16);
         charsTable->goToChar(code);
         return;
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -471,16 +471,11 @@ void MainWindow::setFontItalic(bool enable)
     setFontStyle(newFont);
 }
 
-void MainWindow::setFontSize(qreal size)
-{
-    QFont newFont = fontStyle;
-    newFont.setPointSizeF(size);
-    setFontStyle(newFont);
-}
-
 void MainWindow::setFontSize(const QString & size)
 {
-    setFontSize(size.toDouble());
+    QFont newFont = fontStyle;
+    newFont.setPointSizeF(size.toDouble());
+    setFontStyle(newFont);
 }
 
 void MainWindow::setFontAutoMerging(bool enable)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -64,7 +64,6 @@ public slots:
     void setFontFamily(const QString & family);
     void setFontBold(bool enable);
     void setFontItalic(bool enable);
-    void setFontSize(qreal size);
     void setFontSize(const QString & size);
     void setFontAutoMerging(bool enable);
     void setFontAntialiasing(bool enable);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -8,7 +8,7 @@
 #include <QFontDatabase>
 #include <QMap>
 #include <QClipboard>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QDropEvent>
 #include <QDragEnterEvent>
 
@@ -16,7 +16,7 @@ class MainWindow : public QMainWindow, Ui::MainWindow
 {
     Q_OBJECT
 
-    static QRegExp unicodeRegExp/*, utf8RegExp*/;
+    static QRegularExpression unicodeRegExp/*, utf8RegExp*/;
     QFontDatabase fontDatabase;
     bool antialiasing, autoMerging, systemColors;
     QFont fontStyle;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -832,7 +832,7 @@
   </connection>
   <connection>
    <sender>fontSize</sender>
-   <signal>activated(QString)</signal>
+   <signal>textActivated(QString)</signal>
    <receiver>MainWindow</receiver>
    <slot>setFontSize(QString)</slot>
    <hints>
@@ -902,7 +902,6 @@
   <slot>setFontBold(bool)</slot>
   <slot>setFontItalic(bool)</slot>
   <slot>setFontSize(QString)</slot>
-  <slot>setFontSize(int)</slot>
   <slot>forceUpdateFontList()</slot>
   <slot>makePangram()</slot>
  </slots>


### PR DESCRIPTION
- **QRegExp -> QRegularExpression**
- **use textActivated signal with setFontSize**

Also just in case it matters somehow, this didn't break Qt5 compatibility.
